### PR TITLE
Add method to clean up remaining backup test indices

### DIFF
--- a/lib/elasticsearch_s3_backup.rb
+++ b/lib/elasticsearch_s3_backup.rb
@@ -169,7 +169,7 @@ module EverTools
     end
 
     def delete_test_indexes
-      tries ||= 1 #This seems pretty awful. Couldn't we use a boolean?
+      tries ||= 1
       [@restore_test_index, @backup_test_index].each do |test_index|
         es_api.indices.delete index: test_index
       end
@@ -185,9 +185,8 @@ module EverTools
       # Gather backup test indices
       es_api.indices.get(index: 'backup_test_*').each do |test_index, value|
         # Check again that they are backup test indices
-        if test_index =~ /backup_test_(.*)/  
-          es_api.indices.delete(index: test_index)
-        end
+        es_api.indices.delete index: test_index if test_index =~ /backup_test_(.*)/
+      end
     end
     
     # rubocop:disable Metrics/AbcSize, Lint/RescueException

--- a/lib/elasticsearch_s3_backup.rb
+++ b/lib/elasticsearch_s3_backup.rb
@@ -169,7 +169,7 @@ module EverTools
     end
 
     def delete_test_indexes
-      tries ||= 1
+      tries ||= 1 #This seems pretty awful. Couldn't we use a boolean?
       [@restore_test_index, @backup_test_index].each do |test_index|
         es_api.indices.delete index: test_index
       end
@@ -180,6 +180,16 @@ module EverTools
       retry if tries >= 0
     end
 
+    def cleanup_test_indexes
+      logger.info "Removing remnant test indexes..."
+      # Gather backup test indices
+      es_api.indices.get(index: 'backup_test_*').each do |test_index, value|
+        # Check again that they are backup test indices
+        if test_index =~ /backup_test_(.*)/  
+          es_api.indices.delete(index: test_index)
+        end
+    end
+    
     # rubocop:disable Metrics/AbcSize, Lint/RescueException
     def run
       unless master?
@@ -187,6 +197,7 @@ module EverTools
         exit
       end
 
+      cleanup_test_indexes 
       insert_test_data
 
       # Create a new repo if none exists (typically at beginning of month)


### PR DESCRIPTION
The included method verifies twice that the name of the indices being deleted matches with "backup_test_*" so as to minimize possible operator or code error. 